### PR TITLE
Switch core to braver-core fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository holds the build tools needed to build the Brave desktop browser 
   - [Chromium](https://chromium.googlesource.com/chromium/src.git)
     - Fetches code via `depot_tools`.
     - sets the branch for Chromium (ex: 65.0.3325.181).
-  - [brave-core](https://github.com/braver/braver-core)
+  - [brave-core](https://github.com/braver-browser/braver-core)
     - Mounted at `src/brave`.
     - Maintains patches for 3rd party Chromium code.
   - [adblock-rust](https://github.com/brave/adblock-rust)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "dir": "src/brave",
         "branch": "master",
         "repository": {
-          "url": "https://github.com/brave/brave-core.git"
+          "url": "https://github.com/braver-browser/braver-core.git"
         }
       }
     },
@@ -57,7 +57,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/brave/brave-browser.git"
+    "url": "git+https://github.com/braver-browser/braver-browser.git"
   },
   "author": {
     "name": "Brave Software <support@brave.com>"
@@ -254,9 +254,9 @@
   ],
   "license": "MPL-2.0",
   "bugs": {
-    "url": "https://github.com/brave/brave-browser/issues"
+    "url": "https://github.com/braver-browser/brave-browser/issues"
   },
-  "homepage": "https://github.com/brave/brave-browser#readme",
+  "homepage": "https://github.com/braver-browser/brave-browser#readme",
   "dependencies": {
     "chalk": "^2.4.2",
     "commander": "^2.9.0",


### PR DESCRIPTION
Switches out `brave-core` with `braver-core` so we are building the browser using the right core lib. 

Also other slight changes to indicate the same idea.